### PR TITLE
Remove extra 3 from port name

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ or
 pnpm serve
 ```
 
-This will start a local server and serve the widget at `http://localhost:33333/index.html`.
+This will start a local server and serve the widget at `http://localhost:3333/index.html`.
 
 ## Deploying the Widget to a CDN
 


### PR DESCRIPTION
Just tried to use this and the bundled widget is at port:
http://localhost:3333/index.html


Great work on this overall though 🙌 